### PR TITLE
Have Jax as build variant

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,14 @@ build:
   script: {{ PYTHON }} -m pip install . -vv
   number: 1
 
+test:
+  imports:
+    - alchemlyb
+  commands:
+    - pip check
+  requires:
+    - pip
+
 outputs:
   - name: {{ name }}-core
     requirements:
@@ -38,14 +46,6 @@ outputs:
       run:
         - {{ pin_subpackage('pymbar-core', exact=True) }}
         - pymbar >=4
-
-test:
-  imports:
-    - alchemlyb
-  commands:
-    - pip check
-  requires:
-    - pip
 
 about:
   home: https://github.com/alchemistry/alchemlyb

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: python -m pip install . -vv
   number: 1
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,22 +12,32 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
-requirements:
-  host:
-    - pip
-    - python >=3.8
-  run:
-    - loguru
-    - matplotlib-base
-    - numpy
-    - pandas >=1.4
-    - pyarrow
-    - pymbar >=4
-    - python >=3.8
-    - scikit-learn
-    - scipy
+outputs:
+  - name: {{ name }}-core
+    requirements:
+      host:
+        - pip
+        - python >=3.8
+      run:
+        - loguru
+        - matplotlib-base
+        - numpy
+        - pandas >=1.4
+        - pyarrow
+        - pymbar-core >=4
+        - python >=3.8
+        - scikit-learn
+        - scipy
+
+  - name: {{ name }}
+    requirements:
+      host:
+        - python
+      run:
+        - {{ pin_subpackage('pymbar-core', exact=True) }}
+        - pymbar >=4
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,6 @@ source:
 
 build:
   noarch: python
-  script: python -m pip install . -vv
   number: 1
 
 test:
@@ -24,6 +23,7 @@ test:
 
 outputs:
   - name: {{ name }}-core
+    script: python -m pip install . -vv
     requirements:
       host:
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,7 +44,7 @@ outputs:
       host:
         - python
       run:
-        - {{ pin_subpackage('pymbar-core', exact=True) }}
+        - {{ pin_subpackage('alchemlyb-core', exact=True) }}
         - pymbar >=4
 
 about:


### PR DESCRIPTION

This PR create a two new build variant `jax` which will pull in `pymbar` and `core` which will pull in `pymbar-core`.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
